### PR TITLE
Date toinvite

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+LEWISbounce-lewisroberts.xml

--- a/Get-WasteCollectionType.ps1
+++ b/Get-WasteCollectionType.ps1
@@ -14,9 +14,9 @@ $Sender = "Waste Collections <waste_collections@lewisroberts.com>"
 # "Name" = display name, "Value" = email address
 $To = @{
     "Lewis Roberts" = "lewis@lewisroberts.com";
-    "Joe Bloggs" = "joe.bloggs@lewisroberts.com";
+    #"Joe Bloggs" = "joe.bloggs@lewisroberts.com";
 }
-# Can be accessed as $To.`Lewis Roberts`
+# Can be accessed as $To.`Lewis Roberts` if you like.
 
 # I always use Gmail for the solution so I'm not providing control
 # over the use of EnableSSL, it is ALWAYS enabled.
@@ -94,6 +94,11 @@ For ($i = 0; $i -le ($collectionDates.Count-1); $i++) {
 # Select only the dates that occur in the next 6 days (ie. just this week's collections)
 [Array]$Fragment = $collectionDates | Where {$_.Date -le (Get-Date).AddDays(6)} | Select-Object Date,Type
 
+# To set a reminder (invite) date on the evening before the collection, we need to know
+# the date of the collection. This is sent to the Send-WasteCollectionInvitations function
+# unedited. It is converted to "the night before" within that function.
+[datetime]$EventDate = $collectionDates | Where {$_.Date -le (Get-Date).AddDays(6)} | Group-Object -Property Date -NoElement | Select-Object -First 1 -Property Name -ExpandProperty Name | Get-Date
+
 # Now change that date to a format we understand and put the collection bin colour in the subject line.
 # I didn't do this earlier because I needed to select dates by calculation.
 For ($i=0;$i -le $Fragment.GetUpperBound(0);$i++) {
@@ -120,4 +125,5 @@ Send-WasteCollectionInvitations -To $To `
                                 -From $Sender `
                                 -Credentials $EmailCredentials `
                                 -Subject $Subject `
+                                -EventDate $EventDate `
                                 -Body $HtmlData

--- a/Send-WasteCollectionInvitations.psm1
+++ b/Send-WasteCollectionInvitations.psm1
@@ -28,6 +28,7 @@
                                     -From 'John Doe <john.doe@gmail.com>' `
                                     -Credentials $SenderCredentials `
                                     -Subject 'Waste Collection' `
+                                    -EventDate $EventDate
                                     -Body $Body
 #>
 Function Send-WasteCollectionInvitations
@@ -51,6 +52,9 @@ Function Send-WasteCollectionInvitations
 
         [Parameter(Mandatory=$true)]
         [string]$Subject,
+
+        [Parameter(Mandatory=$true)]
+        [datetime]$EventDate,
 
         [Parameter(Mandatory=$true)]
         [string]$Body
@@ -82,7 +86,7 @@ Function Send-WasteCollectionInvitations
     # BODY #
     ########
 
-    $TodayUTC = (Get-Date).ToUniversalTime()
+    $EventUTC = $EventDate.ToUniversalTime()
     
     # To have the description of the invite make grammatical sense,
     # I remove the default subject prefix from it.
@@ -101,9 +105,9 @@ Function Send-WasteCollectionInvitations
     [void]$s.AppendLine("METHOD:REQUEST")
     [void]$s.AppendLine("BEGIN:VEVENT")
     #[void]$s.AppendLine("TRANSP:TRANSPARENT")
-    [void]$s.AppendLine([String]::Format("DTSTART:{0:yyyyMMddT190000Z}", $TodayUTC))
-    [void]$s.AppendLine([String]::Format("DTSTAMP:{0:yyyyMMddTHHmmssZ}", $TodayUTC.AddMinutes(-1)))
-    [void]$s.AppendLine([String]::Format("DTEND:{0:yyyyMMddT200000Z}", $TodayUTC))
+    [void]$s.AppendLine([String]::Format("DTSTART:{0:yyyyMMddT190000Z}", $EventUTC.AddDays(-1)))
+    [void]$s.AppendLine([String]::Format("DTSTAMP:{0:yyyyMMddTHHmmssZ}", (Get-Date).ToUniversalTime().AddMinutes(-1)))
+    [void]$s.AppendLine([String]::Format("DTEND:{0:yyyyMMddT200000Z}", $EventUTC.AddDays(-1)))
     [void]$s.AppendLine("LOCATION:Holmes Chapel, Cheshire")
     [void]$s.AppendLine([String]::Format("UID:{0}", [Guid]::NewGuid()))
     [void]$s.AppendLine("ORGANIZER;CN=`""+$Mail.From.DisplayName+"`":MAILTO:"+$Mail.From.Address)


### PR DESCRIPTION
Added ability to extract the next waste collection date as a `[datetime]` from the results and send this in to the invite email so that the invite can be set to occur the day before the waste collection. The reminder/invite still occurs at 7pm but is now always 1 day before the event.
Previously, if the script was executed 2 or 3 days before, the event/invite would have been created for 7 on that date (the day the script was executed) which wasn't helpful when the bin doesn't need to go out for another 1 or 2 days!
